### PR TITLE
クイズ画面をレイアウト分割して読み込むために、resources/js/components/page/Quiz.vueを編集しました。

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -86,6 +86,237 @@
 /************************************************************************/
 /******/ ({
 
+/***/ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/page/Quiz.vue?vue&type=script&lang=js&":
+/*!********************************************************************************************************************************************************************!*\
+  !*** ./node_modules/babel-loader/lib??ref--4-0!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/page/Quiz.vue?vue&type=script&lang=js& ***!
+  \********************************************************************************************************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _layout_TheHeader__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../layout/TheHeader */ "./resources/js/components/layout/TheHeader.vue");
+/* harmony import */ var _layout_TheFooter__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../layout/TheFooter */ "./resources/js/components/layout/TheFooter.vue");
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  components: {
+    TheHeader: _layout_TheHeader__WEBPACK_IMPORTED_MODULE_0__["default"],
+    TheFooter: _layout_TheFooter__WEBPACK_IMPORTED_MODULE_1__["default"]
+  }
+});
+
+/***/ }),
+
 /***/ "./node_modules/process/browser.js":
 /*!*****************************************!*\
   !*** ./node_modules/process/browser.js ***!
@@ -554,10 +785,10 @@ exports.clearImmediate = (typeof self !== "undefined" && self.clearImmediate) ||
 
 /***/ }),
 
-/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/page/Quiz.vue?vue&type=template&id=ee5f848c&":
-/*!************************************************************************************************************************************************************************************************************!*\
-  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/page/Quiz.vue?vue&type=template&id=ee5f848c& ***!
-  \************************************************************************************************************************************************************************************************************/
+/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/layout/TheFooter.vue?vue&type=template&id=1d1ea11c&":
+/*!*******************************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/layout/TheFooter.vue?vue&type=template&id=1d1ea11c& ***!
+  \*******************************************************************************************************************************************************************************************************************/
 /*! exports provided: render, staticRenderFns */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
@@ -569,126 +800,42 @@ var render = function() {
   var _vm = this
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
-  return _c("div", [
-    _vm._m(0),
-    _vm._v(" "),
-    _c("main", [
-      _c("div", { staticClass: "container" }, [
-        _vm._m(1),
-        _vm._v(" "),
-        _c("aside", { staticClass: "col-md-4 col-xs-12" }, [
-          _c("section", { staticClass: "sidebar-sns-section" }, [
-            _c("h3", { staticClass: "text-center sidebar-sns-h3" }, [
-              _vm._v("SNS共有")
-            ]),
-            _vm._v(" "),
-            _c(
-              "div",
-              { staticClass: "sidebar-sns-links" },
-              [
-                _c("social-sharing", {
-                  attrs: { title: "shareボタン" },
-                  inlineTemplate: {
-                    render: function() {
-                      var _vm = this
-                      var _h = _vm.$createElement
-                      var _c = _vm._self._c || _h
-                      return _c(
-                        "div",
-                        { staticClass: "twitter__share" },
-                        [
-                          _c("network", { attrs: { network: "twitter" } }, [
-                            _c("i", { staticClass: "fab fa-twitter" }),
-                            _vm._v(" Twitter\n                ")
-                          ])
-                        ],
-                        1
-                      )
-                    },
-                    staticRenderFns: []
-                  }
-                }),
-                _vm._v(" "),
-                _c("social-sharing", {
-                  attrs: { title: "shareボタン" },
-                  inlineTemplate: {
-                    render: function() {
-                      var _vm = this
-                      var _h = _vm.$createElement
-                      var _c = _vm._self._c || _h
-                      return _c(
-                        "div",
-                        { staticClass: "facebook__share" },
-                        [
-                          _c("network", { attrs: { network: "facebook" } }, [
-                            _c("i", { staticClass: "fab fa-facebook" }),
-                            _vm._v(" Facebook\n                ")
-                          ])
-                        ],
-                        1
-                      )
-                    },
-                    staticRenderFns: []
-                  }
-                }),
-                _vm._v(" "),
-                _c("social-sharing", {
-                  attrs: { title: "shareボタン" },
-                  inlineTemplate: {
-                    render: function() {
-                      var _vm = this
-                      var _h = _vm.$createElement
-                      var _c = _vm._self._c || _h
-                      return _c(
-                        "div",
-                        { staticClass: "line__share" },
-                        [
-                          _c("network", { attrs: { network: "line" } }, [
-                            _c("i", { staticClass: "fab fa-line" }),
-                            _vm._v(" Line\n                ")
-                          ])
-                        ],
-                        1
-                      )
-                    },
-                    staticRenderFns: []
-                  }
-                }),
-                _vm._v(" "),
-                _c("social-sharing", {
-                  attrs: { title: "shareボタン" },
-                  inlineTemplate: {
-                    render: function() {
-                      var _vm = this
-                      var _h = _vm.$createElement
-                      var _c = _vm._self._c || _h
-                      return _c(
-                        "div",
-                        { staticClass: "google__share" },
-                        [
-                          _c("network", { attrs: { network: "googleplus" } }, [
-                            _c("i", { staticClass: "fab fa-google" }),
-                            _vm._v(" google\n                ")
-                          ])
-                        ],
-                        1
-                      )
-                    },
-                    staticRenderFns: []
-                  }
-                })
-              ],
-              1
-            )
-          ]),
-          _vm._v(" "),
-          _vm._m(2)
-        ])
+  return _vm._m(0)
+}
+var staticRenderFns = [
+  function() {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("footer", [
+      _c("div", { staticClass: "container text-center" }, [
+        _c("small", [_vm._v("© 2019 4Answers-quiz. All rights reserved.")])
       ])
-    ]),
-    _vm._v(" "),
-    _vm._m(3)
-  ])
+    ])
+  }
+]
+render._withStripped = true
+
+
+
+/***/ }),
+
+/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/layout/TheHeader.vue?vue&type=template&id=12a31364&":
+/*!*******************************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/layout/TheHeader.vue?vue&type=template&id=12a31364& ***!
+  \*******************************************************************************************************************************************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _vm._m(0)
 }
 var staticRenderFns = [
   function() {
@@ -774,7 +921,159 @@ var staticRenderFns = [
         ])
       ])
     ])
-  },
+  }
+]
+render._withStripped = true
+
+
+
+/***/ }),
+
+/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/page/Quiz.vue?vue&type=template&id=ee5f848c&":
+/*!************************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/page/Quiz.vue?vue&type=template&id=ee5f848c& ***!
+  \************************************************************************************************************************************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "div",
+    [
+      _c("the-header"),
+      _vm._v(" "),
+      _c("main", [
+        _c("div", { staticClass: "container" }, [
+          _vm._m(0),
+          _vm._v(" "),
+          _c("aside", { staticClass: "col-md-4 col-xs-12" }, [
+            _c("section", { staticClass: "sidebar-sns-section" }, [
+              _c("h3", { staticClass: "text-center sidebar-sns-h3" }, [
+                _vm._v("SNS共有")
+              ]),
+              _vm._v(" "),
+              _c(
+                "div",
+                { staticClass: "sidebar-sns-links" },
+                [
+                  _c("social-sharing", {
+                    attrs: { title: "shareボタン" },
+                    inlineTemplate: {
+                      render: function() {
+                        var _vm = this
+                        var _h = _vm.$createElement
+                        var _c = _vm._self._c || _h
+                        return _c(
+                          "div",
+                          { staticClass: "twitter__share" },
+                          [
+                            _c("network", { attrs: { network: "twitter" } }, [
+                              _c("i", { staticClass: "fab fa-twitter" }),
+                              _vm._v(" Twitter\n                ")
+                            ])
+                          ],
+                          1
+                        )
+                      },
+                      staticRenderFns: []
+                    }
+                  }),
+                  _vm._v(" "),
+                  _c("social-sharing", {
+                    attrs: { title: "shareボタン" },
+                    inlineTemplate: {
+                      render: function() {
+                        var _vm = this
+                        var _h = _vm.$createElement
+                        var _c = _vm._self._c || _h
+                        return _c(
+                          "div",
+                          { staticClass: "facebook__share" },
+                          [
+                            _c("network", { attrs: { network: "facebook" } }, [
+                              _c("i", { staticClass: "fab fa-facebook" }),
+                              _vm._v(" Facebook\n                ")
+                            ])
+                          ],
+                          1
+                        )
+                      },
+                      staticRenderFns: []
+                    }
+                  }),
+                  _vm._v(" "),
+                  _c("social-sharing", {
+                    attrs: { title: "shareボタン" },
+                    inlineTemplate: {
+                      render: function() {
+                        var _vm = this
+                        var _h = _vm.$createElement
+                        var _c = _vm._self._c || _h
+                        return _c(
+                          "div",
+                          { staticClass: "line__share" },
+                          [
+                            _c("network", { attrs: { network: "line" } }, [
+                              _c("i", { staticClass: "fab fa-line" }),
+                              _vm._v(" Line\n                ")
+                            ])
+                          ],
+                          1
+                        )
+                      },
+                      staticRenderFns: []
+                    }
+                  }),
+                  _vm._v(" "),
+                  _c("social-sharing", {
+                    attrs: { title: "shareボタン" },
+                    inlineTemplate: {
+                      render: function() {
+                        var _vm = this
+                        var _h = _vm.$createElement
+                        var _c = _vm._self._c || _h
+                        return _c(
+                          "div",
+                          { staticClass: "google__share" },
+                          [
+                            _c(
+                              "network",
+                              { attrs: { network: "googleplus" } },
+                              [
+                                _c("i", { staticClass: "fab fa-google" }),
+                                _vm._v(" google\n                ")
+                              ]
+                            )
+                          ],
+                          1
+                        )
+                      },
+                      staticRenderFns: []
+                    }
+                  })
+                ],
+                1
+              )
+            ]),
+            _vm._v(" "),
+            _vm._m(1)
+          ])
+        ])
+      ]),
+      _vm._v(" "),
+      _c("the-footer")
+    ],
+    1
+  )
+}
+var staticRenderFns = [
   function() {
     var _vm = this
     var _h = _vm.$createElement
@@ -1076,16 +1375,6 @@ var staticRenderFns = [
           _vm._v(" "),
           _c("a", { attrs: { href: "/keyword?initial=を" } }, [_vm._v("を")])
         ])
-      ])
-    ])
-  },
-  function() {
-    var _vm = this
-    var _h = _vm.$createElement
-    var _c = _vm._self._c || _h
-    return _c("footer", [
-      _c("div", { staticClass: "container text-center" }, [
-        _c("small", [_vm._v("© 2019 4Answers-quiz. All rights reserved.")])
       ])
     ])
   }
@@ -13638,6 +13927,112 @@ module.exports = g;
 
 /***/ }),
 
+/***/ "./resources/js/components/layout/TheFooter.vue":
+/*!******************************************************!*\
+  !*** ./resources/js/components/layout/TheFooter.vue ***!
+  \******************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _TheFooter_vue_vue_type_template_id_1d1ea11c___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./TheFooter.vue?vue&type=template&id=1d1ea11c& */ "./resources/js/components/layout/TheFooter.vue?vue&type=template&id=1d1ea11c&");
+/* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+
+var script = {}
+
+
+/* normalize component */
+
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__["default"])(
+  script,
+  _TheFooter_vue_vue_type_template_id_1d1ea11c___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _TheFooter_vue_vue_type_template_id_1d1ea11c___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  false,
+  null,
+  null,
+  null
+  
+)
+
+/* hot reload */
+if (false) { var api; }
+component.options.__file = "resources/js/components/layout/TheFooter.vue"
+/* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/components/layout/TheFooter.vue?vue&type=template&id=1d1ea11c&":
+/*!*************************************************************************************!*\
+  !*** ./resources/js/components/layout/TheFooter.vue?vue&type=template&id=1d1ea11c& ***!
+  \*************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_TheFooter_vue_vue_type_template_id_1d1ea11c___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../../node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!../../../../node_modules/vue-loader/lib??vue-loader-options!./TheFooter.vue?vue&type=template&id=1d1ea11c& */ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/layout/TheFooter.vue?vue&type=template&id=1d1ea11c&");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_TheFooter_vue_vue_type_template_id_1d1ea11c___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_TheFooter_vue_vue_type_template_id_1d1ea11c___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+
+
+
+/***/ }),
+
+/***/ "./resources/js/components/layout/TheHeader.vue":
+/*!******************************************************!*\
+  !*** ./resources/js/components/layout/TheHeader.vue ***!
+  \******************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _TheHeader_vue_vue_type_template_id_12a31364___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./TheHeader.vue?vue&type=template&id=12a31364& */ "./resources/js/components/layout/TheHeader.vue?vue&type=template&id=12a31364&");
+/* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+
+var script = {}
+
+
+/* normalize component */
+
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__["default"])(
+  script,
+  _TheHeader_vue_vue_type_template_id_12a31364___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _TheHeader_vue_vue_type_template_id_12a31364___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  false,
+  null,
+  null,
+  null
+  
+)
+
+/* hot reload */
+if (false) { var api; }
+component.options.__file = "resources/js/components/layout/TheHeader.vue"
+/* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/components/layout/TheHeader.vue?vue&type=template&id=12a31364&":
+/*!*************************************************************************************!*\
+  !*** ./resources/js/components/layout/TheHeader.vue?vue&type=template&id=12a31364& ***!
+  \*************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_TheHeader_vue_vue_type_template_id_12a31364___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../../node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!../../../../node_modules/vue-loader/lib??vue-loader-options!./TheHeader.vue?vue&type=template&id=12a31364& */ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/layout/TheHeader.vue?vue&type=template&id=12a31364&");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_TheHeader_vue_vue_type_template_id_12a31364___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_TheHeader_vue_vue_type_template_id_12a31364___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+
+
+
+/***/ }),
+
 /***/ "./resources/js/components/page/Quiz.vue":
 /*!***********************************************!*\
   !*** ./resources/js/components/page/Quiz.vue ***!
@@ -13648,15 +14043,17 @@ module.exports = g;
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _Quiz_vue_vue_type_template_id_ee5f848c___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Quiz.vue?vue&type=template&id=ee5f848c& */ "./resources/js/components/page/Quiz.vue?vue&type=template&id=ee5f848c&");
-/* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+/* harmony import */ var _Quiz_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Quiz.vue?vue&type=script&lang=js& */ "./resources/js/components/page/Quiz.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport *//* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
 
-var script = {}
+
+
 
 
 /* normalize component */
 
-var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__["default"])(
-  script,
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__["default"])(
+  _Quiz_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
   _Quiz_vue_vue_type_template_id_ee5f848c___WEBPACK_IMPORTED_MODULE_0__["render"],
   _Quiz_vue_vue_type_template_id_ee5f848c___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
   false,
@@ -13670,6 +14067,20 @@ var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_
 if (false) { var api; }
 component.options.__file = "resources/js/components/page/Quiz.vue"
 /* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/components/page/Quiz.vue?vue&type=script&lang=js&":
+/*!************************************************************************!*\
+  !*** ./resources/js/components/page/Quiz.vue?vue&type=script&lang=js& ***!
+  \************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Quiz_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../../node_modules/babel-loader/lib??ref--4-0!../../../../node_modules/vue-loader/lib??vue-loader-options!./Quiz.vue?vue&type=script&lang=js& */ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/page/Quiz.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Quiz_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
 
 /***/ }),
 

--- a/resources/js/components/page/quiz.vue
+++ b/resources/js/components/page/quiz.vue
@@ -1,41 +1,6 @@
 <template>
   <div>
-    <header>
-      <div class="container text-center">
-        <h1>4 Answers Quiz 4択クイズ&クイズ徹底解説</h1>
-        <a href="/">
-          <img class="header-nav__logo" src="/public/images/header-logo.png" />
-        </a>
-      </div>
-      <nav class="navbar navbar-default navbar-static-top">
-        <div class="container">
-          <div class="navbar-header">
-            <button
-                type="button"
-                class="navbar-toggle"
-                data-toggle="collapse"
-                data-target="#navbar-ex-collapse"
-            >
-              <span class="sr-only">Toggle navigation</span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-            </button>
-            <a class="navbar-brand" id="header-nav__home" href="/">ホーム</a>
-          </div>
-          <div class="collapse navbar-collapse" id="navbar-ex-collapse">
-            <ul class="nav navbar-nav navbar-right">
-              <li>
-                <a id="header-nav__login" href="/login">ログイン</a>
-              </li>
-              <li>
-                <a id="header-nav__register" href="/register">ユーザー登録</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </nav>
-    </header>
+    <the-header></the-header>
     <main>
       <div class="container">
         <article class="col-md-8 col-xs-12">
@@ -238,11 +203,18 @@
         </aside>
       </div>
     </main>
-
-    <footer>
-      <div class="container text-center">
-        <small>© 2019 4Answers-quiz. All rights reserved.</small>
-      </div>
-    </footer>
+    <the-footer></the-footer>
   </div>
 </template>
+
+<script>
+import TheHeader from "../layout/TheHeader";
+import TheFooter from "../layout/TheFooter";
+
+export default {
+  components: {
+    TheHeader,
+    TheFooter,
+  }
+};
+</script>


### PR DESCRIPTION
## やったこと

クイズ画面をレイアウト分割して読み込むために、resources/js/components/page/Quiz.vueを編集しました。

headerとthe-footerの部分を削除し、TheHeader.vueファイルとTheFooter.vueファイルのテンプレートをインポートできるようにしました。

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

コードの変更前と変更後で、画像が変化していないことを確認しました。

■変更前
<img width="1181" alt="スクリーンショット 2020-10-15 13 38 29" src="https://user-images.githubusercontent.com/63224224/96077841-c9c27580-0eeb-11eb-81db-d0c8346ff8eb.png">
<img width="1217" alt="スクリーンショット 2020-10-15 13 38 37" src="https://user-images.githubusercontent.com/63224224/96077842-cb8c3900-0eeb-11eb-9208-943b7d6bd110.png">

■変更後
<img width="1183" alt="スクリーンショット 2020-10-15 13 16 08" src="https://user-images.githubusercontent.com/63224224/96077858-d515a100-0eeb-11eb-8404-06a2519e81e4.png">
<img width="1206" alt="スクリーンショット 2020-10-15 13 16 28" src="https://user-images.githubusercontent.com/63224224/96077860-d646ce00-0eeb-11eb-979d-dc082e17d735.png">



## その他

今回は画面の見た目に変更点はありません。
resources/js/components/page/Quiz.vueのファイルの確認をよろしくお願い致します。