### PR TITLE
クイズ画面をレイアウト分割して読み込むために、resources/js/components/page/Quiz.vueを編集しました。

### DIFF
--- a/resources/js/components/page/quiz.vue
+++ b/resources/js/components/page/quiz.vue
@@ -1,41 +1,6 @@
 <template>
   <div>
-    <header>
-      <div class="container text-center">
-        <h1>4 Answers Quiz 4択クイズ&クイズ徹底解説</h1>
-        <a href="/">
-          <img class="header-nav__logo" src="/public/images/header-logo.png" />
-        </a>
-      </div>
-      <nav class="navbar navbar-default navbar-static-top">
-        <div class="container">
-          <div class="navbar-header">
-            <button
-                type="button"
-                class="navbar-toggle"
-                data-toggle="collapse"
-                data-target="#navbar-ex-collapse"
-            >
-              <span class="sr-only">Toggle navigation</span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-            </button>
-            <a class="navbar-brand" id="header-nav__home" href="/">ホーム</a>
-          </div>
-          <div class="collapse navbar-collapse" id="navbar-ex-collapse">
-            <ul class="nav navbar-nav navbar-right">
-              <li>
-                <a id="header-nav__login" href="/login">ログイン</a>
-              </li>
-              <li>
-                <a id="header-nav__register" href="/register">ユーザー登録</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </nav>
-    </header>
+    <the-header></the-header>
     <main>
       <div class="container">
         <article class="col-md-8 col-xs-12">
@@ -238,11 +203,18 @@
         </aside>
       </div>
     </main>
-
-    <footer>
-      <div class="container text-center">
-        <small>© 2019 4Answers-quiz. All rights reserved.</small>
-      </div>
-    </footer>
+    <the-footer></the-footer>
   </div>
 </template>
+
+<script>
+import TheHeader from "../layout/TheHeader";
+import TheFooter from "../layout/TheFooter";
+
+export default {
+  components: {
+    TheHeader,
+    TheFooter,
+  }
+};
+</script>


### PR DESCRIPTION
## やったこと

クイズ画面をレイアウト分割して読み込むために、resources/js/components/page/Quiz.vueを編集しました。

headerとthe-footerの部分を削除し、TheHeader.vueファイルとTheFooter.vueファイルのテンプレートをインポートできるようにしました。

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

コードの変更前と変更後で、画像が変化していないことを確認しました。

■変更前
<img width="1181" alt="スクリーンショット 2020-10-15 13 38 29" src="https://user-images.githubusercontent.com/63224224/96077841-c9c27580-0eeb-11eb-81db-d0c8346ff8eb.png">
<img width="1217" alt="スクリーンショット 2020-10-15 13 38 37" src="https://user-images.githubusercontent.com/63224224/96077842-cb8c3900-0eeb-11eb-9208-943b7d6bd110.png">

■変更後
<img width="1183" alt="スクリーンショット 2020-10-15 13 16 08" src="https://user-images.githubusercontent.com/63224224/96077858-d515a100-0eeb-11eb-8404-06a2519e81e4.png">
<img width="1206" alt="スクリーンショット 2020-10-15 13 16 28" src="https://user-images.githubusercontent.com/63224224/96077860-d646ce00-0eeb-11eb-979d-dc082e17d735.png">



## その他

今回は画面の見た目に変更点はありません。
resources/js/components/page/Quiz.vueのファイルの確認をよろしくお願い致します。