### PR TITLE
コンポーネントとして切り出したランキングのグラフ部分を導入するために、resources/js/components/page/Homevueを編集しました。

### DIFF
--- a/resources/js/components/page/Home.vue
+++ b/resources/js/components/page/Home.vue
@@ -58,7 +58,9 @@
                 <input class="ranking-radio" type="radio" name="ranking-radio" value="3" />今週
               </label>
             </div>
-            <div class="home_quiz__ranking-chart"></div>
+            <div class="home_quiz__ranking-chart">
+              <bar-chart></bar-chart>
+            </div>
           </section>
           <section class="home__notice">
             <h2 class="home__notice-h2">
@@ -81,12 +83,14 @@
 import TheHeader from "../layout/TheHeader";
 import TheFooter from "../layout/TheFooter";
 import TheSidebar from "../layout/TheSidebar";
+import BarChart from "../module/BarChart";
 
 export default {
   components: {
     TheHeader,
     TheFooter,
     TheSidebar,
+    BarChart,
   }
 };
 </script>


### PR DESCRIPTION
## やったこと

コンポーネントとして切り出したランキングのグラフ部分を導入するために、resources/js/components/page/Homevueを編集しました。

## やらないこと

無し

## できるようになること（ユーザ目線）

ホーム画面のランキングでグラフが表示されるようになりました。

## できなくなること（ユーザ目線）

無し

## 動作確認

コンポーネントが正しく読み込まれるかを確認をしました。

■変更前

<img width="1287" alt="スクリーンショット 2020-10-20 10 32 16" src="https://user-images.githubusercontent.com/63224224/96540597-1980b280-12d9-11eb-90aa-0cc5a0130b6d.png">


■変更後

<img width="1233" alt="スクリーンショット 2020-10-20 13 28 58" src="https://user-images.githubusercontent.com/63224224/96540606-1d143980-12d9-11eb-8ee2-bbc91ac46b82.png">


## その他

無し